### PR TITLE
fix: Update dependencies in documentation workflow for compatibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y doxygen graphviz cmake build-essential pkg-config \
-            libprotobuf-dev protobuf-compiler libgrpc-dev libgrpc++-dev \
+            libprotobuf-dev protobuf-compiler protobuf-compiler-grpc \
+            libgrpc-dev libgrpc++-dev libgrpc++1 \
             libopencv-dev
 
       - name: Configure CMake


### PR DESCRIPTION
This pull request makes a minor update to the documentation build workflow by adjusting the installation of gRPC and protobuf dependencies. The changes ensure that the correct packages are installed for building and documenting the project.

- Updated the `docs.yml` workflow to add `protobuf-compiler-grpc` and `libgrpc++1` to the list of installed packages, improving compatibility with gRPC and protobuf requirements.