### PR TITLE
fix: Update dependencies in documentation workflow for completeness

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,6 @@ name: Documentation
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 permissions:
   contents: write
@@ -27,10 +25,56 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y doxygen graphviz cmake build-essential pkg-config \
-            libprotobuf-dev protobuf-compiler protobuf-compiler-grpc \
-            libgrpc-dev libgrpc++-dev libgrpc++1 \
-            libopencv-dev
+          sudo apt-get install -y \
+            build-essential \
+            cmake \
+            pkg-config \
+            git \
+            wget \
+            curl \
+            unzip \
+            ca-certificates \
+            doxygen \
+            graphviz \
+            autoconf \
+            libtool \
+            libssl-dev \
+            zlib1g-dev \
+            libc-ares-dev \
+            libabsl-dev \
+            libprotobuf-dev \
+            protobuf-compiler \
+            protobuf-compiler-grpc \
+            libgrpc++-dev \
+            libgrpc-dev \
+            libopencv-dev \
+            libopencv-contrib-dev \
+            libeigen3-dev \
+            libgflags-dev \
+            libgoogle-glog-dev \
+            libtbb-dev \
+            libatlas-base-dev \
+            liblapack-dev \
+            libblas-dev \
+            libhdf5-dev \
+            libgtk-3-dev \
+            libavcodec-dev \
+            libavformat-dev \
+            libswscale-dev \
+            libv4l-dev \
+            libxvidcore-dev \
+            libx264-dev \
+            libjpeg-dev \
+            libpng-dev \
+            libtiff-dev \
+            gfortran \
+            openexr \
+            python3-dev \
+            python3-numpy \
+            libtbbmalloc2 \
+            libdc1394-dev \
+            libgtest-dev \
+            libgmock-dev
 
       - name: Configure CMake
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_DOCUMENTATION=ON


### PR DESCRIPTION
This pull request updates the documentation workflow configuration in `.github/workflows/docs.yml`. The main changes include removing the workflow trigger for pull requests and significantly expanding the list of dependencies installed during the documentation build process.

Workflow trigger changes:

* Removed the `pull_request` trigger so the documentation workflow now only runs on pushes to the `main` branch, not on pull requests.

Dependency installation updates:

* Expanded the list of installed packages in the "Install dependencies" step to include many additional libraries and tools, improving support for building documentation and related components.