### PR TITLE
refactor: Suppress unused parameter warning in PostprocessDetections …

### DIFF
--- a/server/src/detector_server.cpp
+++ b/server/src/detector_server.cpp
@@ -138,7 +138,7 @@ cv::Mat DetectorServer::RunInference(const cv::Mat& blob) {
 }
 
 std::vector<cv::Rect> DetectorServer::PostprocessDetections(
-    const cv::Mat& network_output, const cv::Mat& original_frame) {
+    const cv::Mat& network_output, const cv::Mat& /* original_frame */) {
   std::vector<cv::Rect> detections;
 
   try {

--- a/shared/src/signal_set.cpp
+++ b/shared/src/signal_set.cpp
@@ -153,7 +153,7 @@ void SignalSet::Stop() {
   int fd = eventfd_.load();
   if (fd != -1) {
     uint64_t dummy = 0;
-    write(fd, &dummy, sizeof(dummy));
+    std::ignore = write(fd, &dummy, sizeof(dummy));
   }
 
   // Wait for the thread to finish


### PR DESCRIPTION
This pull request contains minor improvements focused on code clarity and suppressing compiler warnings. The changes do not affect application logic or functionality.

Code clarity and warning suppression:

* Suppressed unused parameter warning by commenting out the `original_frame` parameter in the `DetectorServer::PostprocessDetections` method signature in `detector_server.cpp`.
* Explicitly ignored the result of the `write` system call to suppress unused result warnings in `SignalSet::Stop` in `signal_set.cpp`.…method