### PR TITLE
refactor: Remove logging methods for polygon configuration and networ…

### DIFF
--- a/server/include/detector_server.h
+++ b/server/include/detector_server.h
@@ -201,21 +201,6 @@ class DetectorServer {
                                const aa::shared::Polygon& polygon);
 
   /**
-   * @brief Log polygon configuration for debugging
-   *
-   * @param polygons Polygons to log
-   */
-  void LogPolygonConfiguration(
-      const std::vector<aa::shared::Polygon>& polygons);
-
-  /**
-   * @brief Log network output dimensions for debugging
-   *
-   * @param network_output Network output to log
-   */
-  void LogNetworkOutput(const cv::Mat& network_output);
-
-  /**
    * @brief Check the health of the server
    *
    * @param request Health check request

--- a/server/src/detector_server.cpp
+++ b/server/src/detector_server.cpp
@@ -221,9 +221,6 @@ std::vector<Detection> DetectorServer::PostprocessDetections(
       return detections;
     }
 
-    LogPolygonConfiguration(polygons);
-    LogNetworkOutput(network_output);
-
     std::vector<Detection> raw_detections = ParseNetworkOutput(network_output);
     std::vector<Detection> nms_detections =
         ApplyNonMaximumSuppression(raw_detections);
@@ -641,27 +638,6 @@ std::vector<const aa::shared::Polygon*> DetectorServer::FindContainingPolygons(
   }
 
   return containing_polygons;
-}
-
-void DetectorServer::LogPolygonConfiguration(
-    const std::vector<aa::shared::Polygon>& polygons) {
-  AA_LOG_DEBUG("Polygon-based detection configuration:");
-  for (size_t i = 0; i < polygons.size(); ++i) {
-    const auto& polygon = polygons[i];
-    AA_LOG_DEBUG("Polygon "
-                 << i << ": type=" << static_cast<int>(polygon.GetType())
-                 << ", priority=" << polygon.GetPriority()
-                 << ", target_classes_count="
-                 << polygon.GetTargetClasses().size()
-                 << ", vertices_count=" << polygon.GetVertices().size());
-  }
-}
-
-void DetectorServer::LogNetworkOutput(const cv::Mat& network_output) {
-  AA_LOG_DEBUG("Network output dims: " << network_output.dims);
-  for (int i = 0; i < network_output.dims; ++i) {
-    AA_LOG_DEBUG("Dimension " << i << ": " << network_output.size[i]);
-  }
 }
 
 bool DetectorServer::ShouldIncludeDetection(


### PR DESCRIPTION
This pull request removes debug logging functionality related to polygon configurations and network output dimensions from the `DetectorServer` class. The main goal is to clean up the codebase by eliminating unused or unnecessary debug methods and their invocations.

Code cleanup and removal of debug logging:

* Removed the `LogPolygonConfiguration` and `LogNetworkOutput` method declarations from the `DetectorServer` class in `detector_server.h`.
* Removed the definitions and implementations of `LogPolygonConfiguration` and `LogNetworkOutput` from `detector_server.cpp`.
* Removed calls to `LogPolygonConfiguration` and `LogNetworkOutput` in the `PostprocessDetections` method to prevent unnecessary debug output.…