### PR TITLE
fix: Update Docker workflow to remove tag trigger and adjust permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,6 @@ name: Build and Push Docker Image
 on:
   push:
     branches: [main]
-    tags: ["v*.*.*"]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -12,13 +11,15 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -43,9 +44,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,8 @@ if(BUILD_DOCS)
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             COMMENT "Generating API documentation with Doxygen"
             VERBATIM)
-    else(DOXYGEN_FOUND)
+        file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/output/output.png DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/docs/html/output)
+    else()
         message("Doxygen need to be installed to generate the doxygen documentation")
-    endif(DOXYGEN_FOUND)
+    endif()
 endif()


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and pushing Docker images, and makes a minor improvement to the CMake build process for documentation. The workflow changes enhance permissions and remove unnecessary steps, while the CMake change ensures an image is copied for documentation output.

**GitHub Actions workflow improvements:**

* Moved the `permissions` block from the top level to under the `build` job and expanded it to include `attestations: write` and `id-token: write`, improving security and support for provenance and OIDC authentication.
* Removed tag-based workflow trigger (`tags: ["v*.*.*"]`), so the workflow now only triggers on pushes to `main`, pull requests to `main`, and manual dispatches.
* Removed the `Set up QEMU` step, likely because multi-architecture builds are not required.

**CMake documentation build improvement:**

* Added a step to copy `output.png` to the documentation output directory when Doxygen is found, ensuring the image is available in the generated docs.